### PR TITLE
Resolved Deepsource PYL-R1723 errors

### DIFF
--- a/rctbot/core/extensions.py
+++ b/rctbot/core/extensions.py
@@ -19,8 +19,8 @@ class Extensions(commands.Cog):
             if item.endswith(f".{module}"):
                 extension = item
                 break
-            else:
-                extension = "youredoingitwrongagainsmh"
+            extension = "youredoingitwrongagainsmh"
+
         try:
             self.bot.load_extension(extension)
         except Exception as e:
@@ -36,8 +36,8 @@ class Extensions(commands.Cog):
             if item.endswith(f".{module}"):
                 extension = item
                 break
-            else:
-                extension = "youredoingitwrongagainsmh"
+            extension = "youredoingitwrongagainsmh"
+
         try:
             self.bot.unload_extension(extension)
         except Exception as e:
@@ -53,8 +53,8 @@ class Extensions(commands.Cog):
             if item.endswith(f".{module}"):
                 extension = item
                 break
-            else:
-                extension = "youredoingitwrongagainsmh"
+            extension = "youredoingitwrongagainsmh"
+
         try:
             self.bot.reload_extension(extension)
         except Exception as e:

--- a/rctbot/extensions/trivia/admin.py
+++ b/rctbot/extensions/trivia/admin.py
@@ -212,7 +212,8 @@ class TriviaAdmin(commands.Cog):
                         await self.q_qol.find_one_and_replace(question_doc, prepare_doc)
                         await confirm.add_reaction("👌")
                         break
-                    elif confirm.content.lower() == "no":
+
+                    if confirm.content.lower() == "no":
                         await ctx.send("Aborting..")
                         break
                 except asyncio.TimeoutError:

--- a/utils/phpserialize.py
+++ b/utils/phpserialize.py
@@ -468,7 +468,8 @@ def load(
             char = fp.read(1)
             if char == delim:
                 break
-            elif not char:
+
+            if not char:
                 raise ValueError("unexpected end of stream")
             buf.append(char)
         return b"".join(buf)
@@ -478,7 +479,7 @@ def load(
         _expect(b"{")
         result = []
         last_item = Ellipsis
-        for idx in xrange(items):
+        for _ in xrange(items):
             item = _unserialize()
             if last_item is Ellipsis:
                 last_item = item


### PR DESCRIPTION
# Bugfix

Resolved Deepsource PYL-R1723 errors (`Unnecessary "elif" after "break"`)
- Reference: https://deepsource.io/gh/djuresic/rctbot-discord/issue/PYL-R1723/occurrences