### PR TITLE
Deepsource bugfixes (minor)

### DIFF
--- a/rctbot/core/extensions.py
+++ b/rctbot/core/extensions.py
@@ -19,8 +19,8 @@ class Extensions(commands.Cog):
             if item.endswith(f".{module}"):
                 extension = item
                 break
-            else:
-                extension = "youredoingitwrongagainsmh"
+            extension = "youredoingitwrongagainsmh"
+
         try:
             self.bot.load_extension(extension)
         except Exception as e:
@@ -36,8 +36,8 @@ class Extensions(commands.Cog):
             if item.endswith(f".{module}"):
                 extension = item
                 break
-            else:
-                extension = "youredoingitwrongagainsmh"
+            extension = "youredoingitwrongagainsmh"
+
         try:
             self.bot.unload_extension(extension)
         except Exception as e:
@@ -53,8 +53,8 @@ class Extensions(commands.Cog):
             if item.endswith(f".{module}"):
                 extension = item
                 break
-            else:
-                extension = "youredoingitwrongagainsmh"
+            extension = "youredoingitwrongagainsmh"
+
         try:
             self.bot.reload_extension(extension)
         except Exception as e:

--- a/rctbot/core/rct/cycle.py
+++ b/rctbot/core/rct/cycle.py
@@ -90,10 +90,11 @@ class CycleManager:
         )
         bugs = await (self.testing_bugs.find({})).to_list(length=None)
         extra = await (self.testing_extra.find({})).to_list(length=None)
-        if len(games) == 0 or len(testers) == 0:
+        if 0 in (len(games), len(testers)):
             # TODO: Result
             print("len games testers 0")
             return False
+
         start = datetime.fromtimestamp(games[0]["timestamp"])
         if not (last_cycle := await self.testing_cycles.find_one({}, {"_id": 1}, sort=list({"_id": -1}.items()))):
             id_ = 1

--- a/rctbot/core/rct/cycle.py
+++ b/rctbot/core/rct/cycle.py
@@ -263,7 +263,7 @@ class CycleManager:
         )
         if result.acknowledged:
             return f"Found {result.matched_count} and updated {result.modified_count} members' perks status."
-        return f"Could not update perks status!"
+        return "Could not update perks status!"
 
     async def distribute_tokens(self):
         """

--- a/rctbot/core/webhooks.py
+++ b/rctbot/core/webhooks.py
@@ -28,7 +28,7 @@ async def webhook_embed(
         title=title, type="rich", description=description, color=color, timestamp=datetime.now(timezone.utc),
     )
     embed.set_author(
-        name=author_name, url=f"https://www.heroesofnewerth.com/playerstats/ranked/", icon_url=author_icon,
+        name=author_name, url="https://www.heroesofnewerth.com/playerstats/ranked/", icon_url=author_icon,
     )
 
     for field in fields:

--- a/rctbot/extensions/dev.py
+++ b/rctbot/extensions/dev.py
@@ -37,7 +37,7 @@ class Development(commands.Cog):
         )
         if result.acknowledged:
             await ctx.send(f"Found {result.matched_count} and updated {result.modified_count} members' extra amount.")
-        await ctx.send(f"Could not update perks status!")
+        await ctx.send("Could not update perks status!")
 
     @commands.command()
     @commands.is_owner()

--- a/rctbot/extensions/rct/welcome.py
+++ b/rctbot/extensions/rct/welcome.py
@@ -103,7 +103,7 @@ class RCTWelcome(commands.Cog):
         staff = discord.utils.get(guild.roles, name="Frostburn Staff")
 
         embed = discord.Embed(
-            title=f"Welcome to the official Retail Candidate Testers Discord Server!",
+            title="Welcome to the official Retail Candidate Testers Discord Server!",
             type="rich",
             description=(
                 f"In order to chat here and access the rest of the server, you are required to link your Heroes of"

--- a/rctbot/extensions/trivia/admin.py
+++ b/rctbot/extensions/trivia/admin.py
@@ -212,7 +212,8 @@ class TriviaAdmin(commands.Cog):
                         await self.q_qol.find_one_and_replace(question_doc, prepare_doc)
                         await confirm.add_reaction("👌")
                         break
-                    elif confirm.content.lower() == "no":
+
+                    if confirm.content.lower() == "no":
                         await ctx.send("Aborting..")
                         break
                 except asyncio.TimeoutError:

--- a/rctbot/extensions/trivia/game.py
+++ b/rctbot/extensions/trivia/game.py
@@ -489,7 +489,6 @@ class TriviaGame(commands.Cog):
             )
 
         while True:
-
             try:
                 msg = await self.bot.wait_for("message", timeout=60.0, check=check)
                 msg_count += 1

--- a/utils/phpserialize.py
+++ b/utils/phpserialize.py
@@ -468,7 +468,8 @@ def load(
             char = fp.read(1)
             if char == delim:
                 break
-            elif not char:
+
+            if not char:
                 raise ValueError("unexpected end of stream")
             buf.append(char)
         return b"".join(buf)
@@ -478,7 +479,7 @@ def load(
         _expect(b"{")
         result = []
         last_item = Ellipsis
-        for idx in xrange(items):
+        for _ in xrange(items):
             item = _unserialize()
             if last_item is Ellipsis:
                 last_item = item

--- a/utils/phpserialize.py
+++ b/utils/phpserialize.py
@@ -379,47 +379,47 @@ def dumps(data, charset="utf-8", errors=default_errors, object_hook=None):
             if obj is None:
                 return b's:0:"";'
             raise TypeError("can't serialize %r as key" % type(obj))
-        else:
-            if obj is None:
-                return b"N;"
-            if isinstance(obj, bool):
-                return ("b:%i;" % obj).encode("latin1")
-            if isinstance(obj, (int, long)):
-                return ("i:%s;" % obj).encode("latin1")
-            if isinstance(obj, float):
-                return ("d:%s;" % obj).encode("latin1")
-            if isinstance(obj, basestring):
-                encoded_obj = obj
-                if isinstance(obj, unicode):
-                    encoded_obj = obj.encode(charset, errors)
-                s = BytesIO()
-                s.write(b"s:")
-                s.write(str(len(encoded_obj)).encode("latin1"))
-                s.write(b':"')
-                s.write(encoded_obj)
-                s.write(b'";')
-                return s.getvalue()
-            if isinstance(obj, (list, tuple, dict)):
-                out = []
-                if isinstance(obj, dict):
-                    iterable = obj.items()
-                else:
-                    iterable = enumerate(obj)
-                for key, value in iterable:
-                    out.append(_serialize(key, True))
-                    out.append(_serialize(value, False))
-                return b"".join(
-                    [b"a:", str(len(obj)).encode("latin1"), b":{", b"".join(out), b"}"]
-                )
-            if isinstance(obj, phpobject):
-                return (
-                    b"O"
-                    + _serialize(obj.__name__, True)[1:-1]
-                    + _serialize(obj.__php_vars__, False)[1:]
-                )
-            if object_hook is not None:
-                return _serialize(object_hook(obj), False)
-            raise TypeError("can't serialize %r" % type(obj))
+
+        if obj is None:
+            return b"N;"
+        if isinstance(obj, bool):
+            return ("b:%i;" % obj).encode("latin1")
+        if isinstance(obj, (int, long)):
+            return ("i:%s;" % obj).encode("latin1")
+        if isinstance(obj, float):
+            return ("d:%s;" % obj).encode("latin1")
+        if isinstance(obj, basestring):
+            encoded_obj = obj
+            if isinstance(obj, unicode):
+                encoded_obj = obj.encode(charset, errors)
+            s = BytesIO()
+            s.write(b"s:")
+            s.write(str(len(encoded_obj)).encode("latin1"))
+            s.write(b':"')
+            s.write(encoded_obj)
+            s.write(b'";')
+            return s.getvalue()
+        if isinstance(obj, (list, tuple, dict)):
+            out = []
+            if isinstance(obj, dict):
+                iterable = obj.items()
+            else:
+                iterable = enumerate(obj)
+            for key, value in iterable:
+                out.append(_serialize(key, True))
+                out.append(_serialize(value, False))
+            return b"".join(
+                [b"a:", str(len(obj)).encode("latin1"), b":{", b"".join(out), b"}"]
+            )
+        if isinstance(obj, phpobject):
+            return (
+                b"O"
+                + _serialize(obj.__name__, True)[1:-1]
+                + _serialize(obj.__php_vars__, False)[1:]
+            )
+        if object_hook is not None:
+            return _serialize(object_hook(obj), False)
+        raise TypeError("can't serialize %r" % type(obj))
 
     return _serialize(data, False)
 

--- a/utils/phpserialize.py
+++ b/utils/phpserialize.py
@@ -264,7 +264,7 @@ except LookupError:
 try:
     from StringIO import StringIO as BytesIO
 except ImportError:
-    from io import BytesIO as BytesIO
+    from io import BytesIO
 
 try:
     unicode
@@ -306,7 +306,7 @@ def _translate_member_name(name):
     return name
 
 
-class phpobject(object):
+class phpobject():
     """Simple representation for PHP objects.  This is used """
 
     __slots__ = ("__name__", "__php_vars__")
@@ -352,7 +352,7 @@ def convert_member_dict(d):
     ...                      "default", " * is_active": True})
     {'username': 'user1', 'password': 'default', 'is_active': True}
     """
-    return dict((_translate_member_name(k), v) for k, v in d.items())
+    return {_translate_member_name(k): v for k, v in d.items()}
 
 
 def dumps(data, charset="utf-8", errors=default_errors, object_hook=None):
@@ -379,47 +379,47 @@ def dumps(data, charset="utf-8", errors=default_errors, object_hook=None):
             if obj is None:
                 return b's:0:"";'
             raise TypeError("can't serialize %r as key" % type(obj))
-        else:
-            if obj is None:
-                return b"N;"
-            if isinstance(obj, bool):
-                return ("b:%i;" % obj).encode("latin1")
-            if isinstance(obj, (int, long)):
-                return ("i:%s;" % obj).encode("latin1")
-            if isinstance(obj, float):
-                return ("d:%s;" % obj).encode("latin1")
-            if isinstance(obj, basestring):
-                encoded_obj = obj
-                if isinstance(obj, unicode):
-                    encoded_obj = obj.encode(charset, errors)
-                s = BytesIO()
-                s.write(b"s:")
-                s.write(str(len(encoded_obj)).encode("latin1"))
-                s.write(b':"')
-                s.write(encoded_obj)
-                s.write(b'";')
-                return s.getvalue()
-            if isinstance(obj, (list, tuple, dict)):
-                out = []
-                if isinstance(obj, dict):
-                    iterable = obj.items()
-                else:
-                    iterable = enumerate(obj)
-                for key, value in iterable:
-                    out.append(_serialize(key, True))
-                    out.append(_serialize(value, False))
-                return b"".join(
-                    [b"a:", str(len(obj)).encode("latin1"), b":{", b"".join(out), b"}"]
-                )
-            if isinstance(obj, phpobject):
-                return (
-                    b"O"
-                    + _serialize(obj.__name__, True)[1:-1]
-                    + _serialize(obj.__php_vars__, False)[1:]
-                )
-            if object_hook is not None:
-                return _serialize(object_hook(obj), False)
-            raise TypeError("can't serialize %r" % type(obj))
+        
+        if obj is None:
+            return b"N;"
+        if isinstance(obj, bool):
+            return ("b:%i;" % obj).encode("latin1")
+        if isinstance(obj, (int, long)):
+            return ("i:%s;" % obj).encode("latin1")
+        if isinstance(obj, float):
+            return ("d:%s;" % obj).encode("latin1")
+        if isinstance(obj, basestring):
+            encoded_obj = obj
+            if isinstance(obj, unicode):
+                encoded_obj = obj.encode(charset, errors)
+            s = BytesIO()
+            s.write(b"s:")
+            s.write(str(len(encoded_obj)).encode("latin1"))
+            s.write(b':"')
+            s.write(encoded_obj)
+            s.write(b'";')
+            return s.getvalue()
+        if isinstance(obj, (list, tuple, dict)):
+            out = []
+            if isinstance(obj, dict):
+                iterable = obj.items()
+            else:
+                iterable = enumerate(obj)
+            for key, value in iterable:
+                out.append(_serialize(key, True))
+                out.append(_serialize(value, False))
+            return b"".join(
+                [b"a:", str(len(obj)).encode("latin1"), b":{", b"".join(out), b"}"]
+            )
+        if isinstance(obj, phpobject):
+            return (
+                b"O"
+                + _serialize(obj.__name__, True)[1:-1]
+                + _serialize(obj.__php_vars__, False)[1:]
+            )
+        if object_hook is not None:
+            return _serialize(object_hook(obj), False)
+        raise TypeError("can't serialize %r" % type(obj))
 
     return _serialize(data, False)
 

--- a/utils/phpserialize.py
+++ b/utils/phpserialize.py
@@ -379,47 +379,47 @@ def dumps(data, charset="utf-8", errors=default_errors, object_hook=None):
             if obj is None:
                 return b's:0:"";'
             raise TypeError("can't serialize %r as key" % type(obj))
-        
-        if obj is None:
-            return b"N;"
-        if isinstance(obj, bool):
-            return ("b:%i;" % obj).encode("latin1")
-        if isinstance(obj, (int, long)):
-            return ("i:%s;" % obj).encode("latin1")
-        if isinstance(obj, float):
-            return ("d:%s;" % obj).encode("latin1")
-        if isinstance(obj, basestring):
-            encoded_obj = obj
-            if isinstance(obj, unicode):
-                encoded_obj = obj.encode(charset, errors)
-            s = BytesIO()
-            s.write(b"s:")
-            s.write(str(len(encoded_obj)).encode("latin1"))
-            s.write(b':"')
-            s.write(encoded_obj)
-            s.write(b'";')
-            return s.getvalue()
-        if isinstance(obj, (list, tuple, dict)):
-            out = []
-            if isinstance(obj, dict):
-                iterable = obj.items()
-            else:
-                iterable = enumerate(obj)
-            for key, value in iterable:
-                out.append(_serialize(key, True))
-                out.append(_serialize(value, False))
-            return b"".join(
-                [b"a:", str(len(obj)).encode("latin1"), b":{", b"".join(out), b"}"]
-            )
-        if isinstance(obj, phpobject):
-            return (
-                b"O"
-                + _serialize(obj.__name__, True)[1:-1]
-                + _serialize(obj.__php_vars__, False)[1:]
-            )
-        if object_hook is not None:
-            return _serialize(object_hook(obj), False)
-        raise TypeError("can't serialize %r" % type(obj))
+        else:
+            if obj is None:
+                return b"N;"
+            if isinstance(obj, bool):
+                return ("b:%i;" % obj).encode("latin1")
+            if isinstance(obj, (int, long)):
+                return ("i:%s;" % obj).encode("latin1")
+            if isinstance(obj, float):
+                return ("d:%s;" % obj).encode("latin1")
+            if isinstance(obj, basestring):
+                encoded_obj = obj
+                if isinstance(obj, unicode):
+                    encoded_obj = obj.encode(charset, errors)
+                s = BytesIO()
+                s.write(b"s:")
+                s.write(str(len(encoded_obj)).encode("latin1"))
+                s.write(b':"')
+                s.write(encoded_obj)
+                s.write(b'";')
+                return s.getvalue()
+            if isinstance(obj, (list, tuple, dict)):
+                out = []
+                if isinstance(obj, dict):
+                    iterable = obj.items()
+                else:
+                    iterable = enumerate(obj)
+                for key, value in iterable:
+                    out.append(_serialize(key, True))
+                    out.append(_serialize(value, False))
+                return b"".join(
+                    [b"a:", str(len(obj)).encode("latin1"), b":{", b"".join(out), b"}"]
+                )
+            if isinstance(obj, phpobject):
+                return (
+                    b"O"
+                    + _serialize(obj.__name__, True)[1:-1]
+                    + _serialize(obj.__php_vars__, False)[1:]
+                )
+            if object_hook is not None:
+                return _serialize(object_hook(obj), False)
+            raise TypeError("can't serialize %r" % type(obj))
 
     return _serialize(data, False)
 


### PR DESCRIPTION
# Deepsource bugfixes (minor)

Resolved the following Deepsource errors:
- PYL-R0205 (useless inheritance from `object` class)
- PTC-W0027 (`f-string` used without any expression)
- PYL-C0414 (import alias same as original package name)
- PTC-W0015 (unnecessary generator - rewrite as dict comprehension)
- PYL-R1720 (unnecessary `else/elif` used after raise)
- PYL-R1714 (performance-related: consider using `in`)