### PR TITLE
Resolve PYL-R1721 (unnecessary use of comprehenshion)

### DIFF
--- a/rctbot/extensions/trivia/game.py
+++ b/rctbot/extensions/trivia/game.py
@@ -43,7 +43,7 @@ class TriviaGame(commands.Cog):
     """Trivia game class."""
 
     DATABASE = DatabaseHandler.client["Trivia"]
-    QUESTIONS = list(q for q in DATABASE["QUESTIONS"].find({"enabled": True}))
+    QUESTIONS = list(DATABASE["QUESTIONS"].find({"enabled": True}))
 
     def __init__(self, bot):
         self.bot = bot

--- a/rctbot/extensions/trivia/game.py
+++ b/rctbot/extensions/trivia/game.py
@@ -43,7 +43,7 @@ class TriviaGame(commands.Cog):
     """Trivia game class."""
 
     DATABASE = DatabaseHandler.client["Trivia"]
-    QUESTIONS = [q for q in DATABASE["QUESTIONS"].find({"enabled": True})]
+    QUESTIONS = list(q for q in DATABASE["QUESTIONS"].find({"enabled": True}))
 
     def __init__(self, bot):
         self.bot = bot


### PR DESCRIPTION
# Resolve PYL-R1721 (unnecessary use of `comprehenshion`)

Details:
- `DATABASE["QUESTIONS"].find({"enabled": True})` is a `PyMongo` cursor.
- Rather than doing list comprehension, we could just convert the `Pymongo` cursor iterable to a list directly. This change actually saves 1 loop's worth of operations :)

Reference: https://stackoverflow.com/a/63501245